### PR TITLE
Add pkgconfig(gumbo) to devel pacakge

### DIFF
--- a/litehtml.spec
+++ b/litehtml.spec
@@ -57,6 +57,7 @@ Group:		Development/C++
 Provides:	%{name}-devel = %{version}-%{release}
 Provides:	lib%{name}-devel = %{version}-%{release}
 Requires:	%{libname} = %{version}-%{release}
+Requires:	pkgconfig(gumbo)
 
 %description -n %{develname}
 Development files and headers for %{name}.


### PR DESCRIPTION
This is to try to fixe the nothing provides cmake(gumbo) error that was occuring during the test installaiton of the devel package.